### PR TITLE
Add title and long-title to page

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,4 +1,6 @@
-!config navigation breadcrumbs=False scrollspy=False search=False
+!config navigation breadcrumbs=False scrollspy=False search=False long-title=Fourth State Applications Research Laboratory
+
+# HOME style=visibility:hidden;
 
 !style halign=center fontsize=300%
 Fourth State Applications Research Laboratory


### PR DESCRIPTION
This was accidentally removed in the last changeset, since I opted not to use a top-level section. Also took a moment to add a long title to the page metadata.

Refs #2